### PR TITLE
Downgrade datatables-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "doctrine/annotations": "^1.0",
         "doctrine/common": "^2.0",
         "kevinpapst/adminlte-bundle": "^3.0",
-        "omines/datatables-bundle": "^0.4.2"
+        "omines/datatables-bundle": "^0.3|^0.4"
     },
     "autoload": {
         "psr-4": { "Pretorien\\AdminLTEMakerBundle\\": "src/" }


### PR DESCRIPTION
Datatables-bundle ^0.4 requires at least PHP 7.2. This is against de main constraint PHP 7.1 (Symfony 4)